### PR TITLE
On drag/resize, fire onLayoutChange when allowOverlap=true

### DIFF
--- a/lib/ReactGridLayout.jsx
+++ b/lib/ReactGridLayout.jsx
@@ -6,6 +6,7 @@ import clsx from "clsx";
 import {
   bottom,
   childrenEqual,
+  cloneLayout,
   cloneLayoutItem,
   compact,
   compactType,
@@ -252,7 +253,7 @@ export default class ReactGridLayout extends React.Component<Props, State> {
 
     this.setState({
       oldDragItem: cloneLayoutItem(l),
-      oldLayout: layout
+      oldLayout: cloneLayout(layout)
     });
 
     return this.props.onDragStart(layout, l, l, null, e, node);
@@ -385,7 +386,7 @@ export default class ReactGridLayout extends React.Component<Props, State> {
 
     this.setState({
       oldResizeItem: cloneLayoutItem(l),
-      oldLayout: this.state.layout
+      oldLayout: cloneLayout(layout)
     });
 
     this.props.onResizeStart(layout, l, l, null, e, node);


### PR DESCRIPTION
When `allowOverlap` is true, `onLayoutChange` is not fired unless there is collision. This ensures that a clone of the state's layout is always passed to state so that dragging and resizing will always subsequently fire `onLayoutChange`.

Thanks for submitting a pull request to RGL!

Please reference an open issue. If one has not been created, please create one along with a failing
example or test case.

Please do not commit built files (`/dist`) to pull requests. They are built only at release.
